### PR TITLE
Support multiple and non-file inputs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 image_name=alpine-ffmpeg
 
 # docker container names cannot have whitespace
-sed -i -e 's/dffmpeg_image_name=.*/dffmpeg_image_name=$image_name/g' dffmpeg.sh
+sed -i -e "s/dffmpeg_image_name=.*/dffmpeg_image_name=$image_name/g" dffmpeg.sh
 
 cd images/$image_name
 ./build.sh

--- a/dffmpeg.sh
+++ b/dffmpeg.sh
@@ -8,7 +8,8 @@
 
 # The name of the docker image which has ffmpeg as its entrypoint
 dffmpeg_image_name=alpine-ffmpeg
-# The path inside the guest container that will be used as a mountpoint for the host's input (should never need modification)
+# The path inside the guest container that will contain subdirectories
+# used as mountpoints for the host's input (should never need modification)
 guest_input_dir=/tmp/dffmpeg_in
 # The path inside the guest container that will be used as a mountpoint for the host's output (should never need modification)
 guest_output_dir=/tmp/dffmpeg_out
@@ -24,12 +25,13 @@ fi
 
 # Loop through args to determine input and output paths
 host_input_path_is_next=False
+declare -A host_input_paths  # maps (host input path) -> (guest input dir)
 for var in "$@"
 do
   host_output_path="$var"
   if [ "$host_input_path_is_next" == "True" ]
   then
-    host_input_path="$var"
+    host_input_paths[$var]="$guest_input_dir/$(cat /proc/sys/kernel/random/uuid)"
     host_input_path_is_next=False
   fi
   if [ "$var" == "-i" ]
@@ -40,13 +42,16 @@ done
 
 # Build args for guest (replacing input/output paths with their guest equivalents
 guest_args=()
+# mount specs for input file directories
+mount_args=()
 for var in "$@"
 do
   # TODO: consider first checking for nonempty??
   guest_arg="$var"
-  if [ "$var" == "$host_input_path" ]
+  if [ -n "${host_input_paths[$var]}" ]
   then
-    guest_arg="$guest_input_dir/$(basename "$host_input_path")"
+    guest_arg="${host_input_paths[$var]}/$(basename "$var")"
+    mount_args+=(-v "$(dirname "$(realpath "$var")")":"${host_input_paths[$var]}":ro)
   fi
   if [ "$var" == "$host_output_path" ]
   then
@@ -56,13 +61,16 @@ do
 done
 
 
-# Terminate with error if either host input path or host output dir are invalid
+# Terminate with error if any host input path or the host output dir are invalid
 
-if [ ! -f "$host_input_path" ]
-then
-  echo "ERROR: input path \""$host_input_path"\" does not exist!"
-  failure_encountered=True
-fi
+for var in "${!host_input_paths[@]}"
+do
+  if [ ! -f "$var" ]
+  then
+    echo "ERROR: input path \""$var"\" does not exist!"
+    failure_encountered=True
+  fi
+done
 if [ ! -d "$(dirname "$host_output_path")" ]
 then
   echo "ERROR: output directory \""$(dirname "$host_output_path")" does not exist!"
@@ -74,10 +82,10 @@ then
   exit 1
 else
   # Runs the docker container with ffmpeg as its entrypoint
-  # Run configurations: 
+  # Run configurations:
   # Mount the input volume as read only
   # Mount the output volume as rw (overwrites input ro if overlapping)
   # Executes ffmpeg with the same uid and gid as the caller
   # Passes all arguments to the guest container (while appropriately modifying input and output paths)
-  docker run --rm -it -v "$(dirname "$(realpath "$host_input_path")")":"$guest_input_dir":ro -v "$(dirname "$(realpath "$host_output_path")")":"$guest_output_dir" -u $(id -u):$(id -g) "$dffmpeg_image_name" "${guest_args[@]}"
+  docker run --rm -it "${mount_args[@]}" -v "$(dirname "$(realpath "$host_output_path")")":"$guest_output_dir" -u $(id -u):$(id -g) "$dffmpeg_image_name" "${guest_args[@]}"
 fi

--- a/dffmpeg.sh
+++ b/dffmpeg.sh
@@ -31,7 +31,10 @@ do
   host_output_path="$var"
   if [ "$host_input_path_is_next" == "True" ]
   then
-    host_input_paths[$var]="$guest_input_dir/$(cat /proc/sys/kernel/random/uuid)"
+    if ! [[ "$var" =~ ^[0-9a-zA-Z]+://.+ ]]
+    then
+      host_input_paths[$var]="$guest_input_dir/$(cat /proc/sys/kernel/random/uuid)"
+    fi
     host_input_path_is_next=False
   fi
   if [ "$var" == "-i" ]


### PR DESCRIPTION
- Add support for providing multiple inputs (``ffmpeg -i input_1 -i input_2 -other options output``).
- Don't treat inputs matching the regex ``^[0-9a-zA-Z]+://.+`` (e.g. ``https://whatever``) as files, i.e. don't check for existence and attempt to mount their directories in the container.